### PR TITLE
Add Flask web app and Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=web_app.py
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Bingo_card_maker
-Generates bingo cards with templates
+
+This project generates bingo cards based on an uploaded template image. A small Flask web application is provided and wrapped in a Docker container so you can easily create multiple cards through a web interface.
+
+## Usage
+
+1. Build the Docker image:
+   ```bash
+   docker build -t bingo-maker .
+   ```
+
+2. Run the container:
+   ```bash
+   docker run -p 5000:5000 bingo-maker
+   ```
+
+3. Visit `http://localhost:5000` in your browser, upload a template image and choose how many cards to generate. The result will be downloaded as a ZIP file containing the generated images.
+
+The card logic and text positioning mirror the behaviour of `script_v4.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pillow

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Bingo Card Maker</title>
+  </head>
+  <body>
+    <h1>Bingo Card Maker</h1>
+    <form action="/" method="post" enctype="multipart/form-data">
+      <label>Template image: <input type="file" name="template" required></label><br>
+      <label>Number of cards: <input type="number" name="quantity" min="1" max="100" value="4"></label><br>
+      <label>Font path (optional): <input type="text" name="font_path" placeholder="/path/to/font.ttf"></label><br>
+      <input type="submit" value="Generate">
+    </form>
+  </body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,65 @@
+from flask import Flask, request, render_template, send_file
+from PIL import Image, ImageDraw, ImageFont
+import random
+import io
+import zipfile
+
+app = Flask(__name__)
+
+DEFAULT_FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+
+CELL_COORDINATES = [
+    (250 + x * 445, 550 + y * 380)
+    for y in range(5)
+    for x in range(5)
+]
+
+
+def generate_bingo_card():
+    numbers = random.sample(range(1, 76), 25)
+    card = [numbers[i*5:(i+1)*5] for i in range(5)]
+    card[2].insert(2, " ")
+    return card
+
+
+def add_numbers_to_image(image, numbers, font):
+    draw = ImageDraw.Draw(image)
+    for i in range(5):
+        for j in range(5):
+            if not (i == 2 and j == 2):
+                x = 250 + j * 445
+                y = 550 + i * 380
+                number = numbers[i][j]
+                draw.text((x + 45, y + 45), f"{number:02}", fill="white", font=font, anchor="mm")
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded_file = request.files.get('template')
+        quantity = int(request.form.get('quantity', 1))
+        font_path = request.form.get('font_path', '').strip() or DEFAULT_FONT
+        if not uploaded_file:
+            return "Template required", 400
+        try:
+            font = ImageFont.truetype(font_path, 200)
+        except Exception:
+            font = ImageFont.load_default()
+        template = Image.open(uploaded_file.stream).convert('RGBA')
+        mem_zip = io.BytesIO()
+        with zipfile.ZipFile(mem_zip, 'w') as zf:
+            for i in range(quantity):
+                card = generate_bingo_card()
+                card_img = template.copy()
+                add_numbers_to_image(card_img, card, font)
+                img_bytes = io.BytesIO()
+                card_img.save(img_bytes, format='PNG')
+                img_bytes.seek(0)
+                zf.writestr(f'bingo_card_{i+1}.png', img_bytes.read())
+        mem_zip.seek(0)
+        return send_file(mem_zip, mimetype='application/zip', as_attachment=True, download_name='bingo_cards.zip')
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add simple Flask web app to generate bingo cards from uploaded template
- provide HTML form for uploads
- add Dockerfile and requirements for containerized usage
- update README with build and run instructions

## Testing
- `python -m py_compile web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68548d2f8b048331ae298b6341a7c32c