### PR TITLE
Clamp quantity input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ This project generates bingo cards based on an uploaded template image. A small 
    docker run -p 5000:5000 bingo-maker
    ```
 
-3. Visit `http://localhost:5000` in your browser, upload a template image and choose how many cards to generate. The result will be downloaded as a ZIP file containing the generated images.
+3. Visit `http://localhost:5000` in your browser, upload a template image and choose how many cards to generate (between 1 and 100 per request). The result will be downloaded as a ZIP file containing the generated images.
 
 The card logic and text positioning mirror the behaviour of `script_v4.py`.

--- a/web_app.py
+++ b/web_app.py
@@ -37,7 +37,11 @@ def add_numbers_to_image(image, numbers, font):
 def index():
     if request.method == 'POST':
         uploaded_file = request.files.get('template')
-        quantity = int(request.form.get('quantity', 1))
+        try:
+            qty = int(request.form.get("quantity", 1))
+        except ValueError:
+            qty = 1
+        qty = max(1, min(qty, 100))
         font_path = request.form.get('font_path', '').strip() or DEFAULT_FONT
         if not uploaded_file:
             return "Template required", 400
@@ -48,7 +52,7 @@ def index():
         template = Image.open(uploaded_file.stream).convert('RGBA')
         mem_zip = io.BytesIO()
         with zipfile.ZipFile(mem_zip, 'w') as zf:
-            for i in range(quantity):
+            for i in range(qty):
                 card = generate_bingo_card()
                 card_img = template.copy()
                 add_numbers_to_image(card_img, card, font)


### PR DESCRIPTION
## Summary
- sanitize `quantity` input in the Flask app and clamp between 1 and 100
- use new `qty` variable when generating cards
- clarify README about card limit

## Testing
- `python -m py_compile web_app.py script_v4.py`


------
https://chatgpt.com/codex/tasks/task_e_6854933b4bac833180ab47abac96daa2