### PR TITLE
Add font path CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ This project generates bingo cards based on an uploaded template image. A small 
 3. Visit `http://localhost:5000` in your browser, upload a template image and choose how many cards to generate. The result will be downloaded as a ZIP file containing the generated images.
 
 The card logic and text positioning mirror the behaviour of `script_v4.py`.
+
+### Command line usage
+
+You can also generate cards directly with `script_v4.py`:
+
+```bash
+python script_v4.py --font-path /path/to/font.ttf
+```
+
+The `--font-path` option is optional and defaults to
+`/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf`.

--- a/script_v4.py
+++ b/script_v4.py
@@ -1,13 +1,23 @@
 from PIL import Image, ImageDraw, ImageFont
 import random
+import argparse
+
+DEFAULT_FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+
+parser = argparse.ArgumentParser(description="Generate bingo cards from a template image")
+parser.add_argument(
+    "--font-path",
+    default=DEFAULT_FONT,
+    help="Path to a .ttf font file used for drawing the numbers",
+)
+args = parser.parse_args()
 
 # Carregar o template
-template_path = 'Cartela Bingo Arraia do Lowis II.png'
+template_path = "Cartela Bingo Arraia do Lowis II.png"
 template = Image.open(template_path)
 
 # Definir a fonte
-font_path = 'C:\\WINDOWS\\FONTS\\BAUHS93.TTF'
-font = ImageFont.truetype(font_path, 200)  # Escala da fonte ajustada para 2,5 vezes maior
+font = ImageFont.truetype(args.font_path, 200)
 
 # Coordenadas das células na cartela (5x5) escaladas 2,5 vezes
 cell_coordinates = [


### PR DESCRIPTION
## Summary
- allow overriding the font in `script_v4.py` via `--font-path`
- document new option in README

## Testing
- `python -m py_compile script_v4.py`

------
https://chatgpt.com/codex/tasks/task_e_685493c05e608331a6e28f43c28cfec7