### PR TITLE
Use bundled font in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ python script_v4.py --font-path /path/to/font.ttf
 ```
 
 The `--font-path` option is optional and defaults to
-`/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf`.
+the bundled `BAUHS93.ttf` font in this repository.

--- a/script_v4.py
+++ b/script_v4.py
@@ -1,8 +1,9 @@
 from PIL import Image, ImageDraw, ImageFont
 import random
 import argparse
+import os
 
-DEFAULT_FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+DEFAULT_FONT = os.path.join(os.path.dirname(__file__), "BAUHS93.ttf")
 
 parser = argparse.ArgumentParser(description="Generate bingo cards from a template image")
 parser.add_argument(

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
     <form action="/" method="post" enctype="multipart/form-data">
       <label>Template image: <input type="file" name="template" required></label><br>
       <label>Number of cards: <input type="number" name="quantity" min="1" max="100" value="4"></label><br>
-      <label>Font path (optional): <input type="text" name="font_path" placeholder="/path/to/font.ttf"></label><br>
+      <label>Font path (optional): <input type="text" name="font_path" placeholder="BAUHS93.ttf"></label><br>
       <input type="submit" value="Generate">
     </form>
   </body>

--- a/web_app.py
+++ b/web_app.py
@@ -3,10 +3,11 @@ from PIL import Image, ImageDraw, ImageFont
 import random
 import io
 import zipfile
+import os
 
 app = Flask(__name__)
 
-DEFAULT_FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+DEFAULT_FONT = os.path.join(os.path.dirname(__file__), "BAUHS93.ttf")
 
 CELL_COORDINATES = [
     (250 + x * 445, 550 + y * 380)


### PR DESCRIPTION
## Summary
- use `BAUHS93.ttf` that ships with the repo as the default font
- mention bundled font in README
- update placeholder in the form

## Testing
- `python -m py_compile script_v4.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_685495470c208331adb308ff1ca42169