### PR TITLE
Add progress bar with async generation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,11 +6,52 @@
   </head>
   <body>
     <h1>Bingo Card Maker</h1>
-    <form action="/" method="post" enctype="multipart/form-data">
+    <form id="generator-form" enctype="multipart/form-data">
       <label>Template image: <input type="file" name="template" required></label><br>
       <label>Number of cards: <input type="number" name="quantity" min="1" max="100" value="4"></label><br>
       <label>Font path (optional): <input type="text" name="font_path" placeholder="BAUHS93.ttf"></label><br>
       <input type="submit" value="Generate">
     </form>
+    <div style="margin-top:1em;">
+      <progress id="progress" value="0" max="1" style="display:none;width:300px;"></progress>
+      <span id="progress-text"></span>
+    </div>
+    <div><a id="download-link" href="#" style="display:none;">Download ZIP</a></div>
+    <script>
+      const form = document.getElementById('generator-form');
+      const progress = document.getElementById('progress');
+      const progressText = document.getElementById('progress-text');
+      const downloadLink = document.getElementById('download-link');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        progress.style.display = 'block';
+        progress.value = 0;
+        progressText.textContent = '';
+        downloadLink.style.display = 'none';
+        const data = new FormData(form);
+        const res = await fetch('/start', {method: 'POST', body: data});
+        if (!res.ok) {
+          alert('Falha ao iniciar geração');
+          progress.style.display = 'none';
+          return;
+        }
+        const info = await res.json();
+        progress.max = info.qty;
+        const jobId = info.job_id;
+
+        const timer = setInterval(async () => {
+          const r = await fetch('/progress/' + jobId);
+          if (!r.ok) return;
+          const status = await r.json();
+          progress.value = status.progress;
+          progressText.textContent = `${status.progress}/${status.qty} cartelas`;
+          if (status.done) {
+            clearInterval(timer);
+            downloadLink.href = '/download/' + jobId;
+            downloadLink.style.display = 'inline';
+          }
+        }, 500);
+      });
+    </script>
   </body>
 </html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,11 +1,16 @@
-from flask import Flask, request, render_template, send_file
+from flask import Flask, request, render_template, send_file, jsonify
 from PIL import Image, ImageDraw, ImageFont
 import random
 import io
 import zipfile
 import os
+import threading
+import uuid
 
 app = Flask(__name__)
+
+# Store background generation jobs
+jobs = {}
 
 DEFAULT_FONT = os.path.join(os.path.dirname(__file__), "BAUHS93.ttf")
 
@@ -34,36 +39,75 @@ def add_numbers_to_image(image, numbers, font):
                 draw.text((x + 45, y + 45), f"{number:02}", fill="white", font=font, anchor="mm")
 
 
-@app.route('/', methods=['GET', 'POST'])
-def index():
-    if request.method == 'POST':
-        uploaded_file = request.files.get('template')
-        try:
-            qty = int(request.form.get("quantity", 1))
-        except ValueError:
-            qty = 1
-        qty = max(1, min(qty, 100))
-        font_path = request.form.get('font_path', '').strip() or DEFAULT_FONT
-        if not uploaded_file:
-            return "Template required", 400
+def _generate_job(job_id, template_bytes, qty, font_path):
+    """Background thread that generates bingo cards and updates progress."""
+    try:
         try:
             font = ImageFont.truetype(font_path, 200)
         except Exception:
             font = ImageFont.load_default()
-        template = Image.open(uploaded_file.stream).convert('RGBA')
+
+        template = Image.open(io.BytesIO(template_bytes)).convert("RGBA")
         mem_zip = io.BytesIO()
-        with zipfile.ZipFile(mem_zip, 'w') as zf:
+        with zipfile.ZipFile(mem_zip, "w") as zf:
             for i in range(qty):
                 card = generate_bingo_card()
                 card_img = template.copy()
                 add_numbers_to_image(card_img, card, font)
                 img_bytes = io.BytesIO()
-                card_img.save(img_bytes, format='PNG')
+                card_img.save(img_bytes, format="PNG")
                 img_bytes.seek(0)
-                zf.writestr(f'bingo_card_{i+1}.png', img_bytes.read())
+                zf.writestr(f"bingo_card_{i+1}.png", img_bytes.read())
+                jobs[job_id]["progress"] = i + 1
         mem_zip.seek(0)
-        return send_file(mem_zip, mimetype='application/zip', as_attachment=True, download_name='bingo_cards.zip')
+        jobs[job_id]["zip"] = mem_zip
+        jobs[job_id]["done"] = True
+    except Exception:
+        jobs[job_id]["error"] = True
+        jobs[job_id]["done"] = True
+
+
+@app.route('/', methods=['GET'])
+def index():
     return render_template('index.html')
+
+
+@app.route('/start', methods=['POST'])
+def start_generation():
+    uploaded_file = request.files.get('template')
+    if not uploaded_file:
+        return jsonify({'error': 'Template required'}), 400
+    try:
+        qty = int(request.form.get('quantity', 1))
+    except ValueError:
+        qty = 1
+    qty = max(1, min(qty, 100))
+    font_path = request.form.get('font_path', '').strip() or DEFAULT_FONT
+    template_bytes = uploaded_file.read()
+
+    job_id = uuid.uuid4().hex
+    jobs[job_id] = {'progress': 0, 'qty': qty, 'done': False}
+    thread = threading.Thread(target=_generate_job, args=(job_id, template_bytes, qty, font_path))
+    thread.start()
+    return jsonify({'job_id': job_id, 'qty': qty})
+
+
+@app.route('/progress/<job_id>')
+def job_progress(job_id):
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({'error': 'Invalid job'}), 404
+    return jsonify({'progress': job.get('progress', 0), 'qty': job['qty'], 'done': job.get('done', False)})
+
+
+@app.route('/download/<job_id>')
+def download_job(job_id):
+    job = jobs.get(job_id)
+    if not job or not job.get('done'):
+        return jsonify({'error': 'Not ready'}), 404
+    mem_zip = job.get('zip')
+    mem_zip.seek(0)
+    return send_file(mem_zip, mimetype='application/zip', as_attachment=True, download_name='bingo_cards.zip')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add asynchronous endpoints and background job handling
- show progress bar and counter while generating cards
- provide download link when ready

## Testing
- `python -m py_compile web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_685496f997948331b06eb841de8dfd38